### PR TITLE
Add dup status check

### DIFF
--- a/bot_utils/db_utils.py
+++ b/bot_utils/db_utils.py
@@ -59,11 +59,11 @@ def check_time_room_conflict(a_time, a_room):
     about the same event sent by multiple users. Currently the retweets
     from bot are first come first serve for a unqiue room and time stamp. 
     """
-    event_conflict = models.Event.objects.filter(location=a_room, start=a_time)
+    event_conflict = models.RetweetEvent.objects.filter(location=a_room, start=a_time)
     return True if event_conflict else False
 
 def create_event(**kwargs):
     """
     Create event record with a description, creator, time, and room
     """
-    models.Event.objects.create(**kwargs)
+    models.RetweetEvent.objects.create(**kwargs)

--- a/bot_utils/db_utils.py
+++ b/bot_utils/db_utils.py
@@ -51,3 +51,19 @@ def save_outgoing_tweet(tweet_obj):
                                      approved=tweet_obj["approved"], 
                                      scheduled_time=tweet_obj["remind_time"])
     tweet_obj.save()
+
+def check_time_room_conflict(a_time, a_room):
+    """
+    Check to see if there is already a tweet scheduled to go out about 
+    an event in the same time and room. Helps avoid duplicate retweets
+    about the same event sent by multiple users. Currently the retweets
+    from bot are first come first serve for a unqiue room and time stamp. 
+    """
+    event_conflict = models.Event.objects.filter(location=a_room, start=a_time)
+    return True if event_conflict else False
+
+def create_event(**kwargs):
+    """
+    Create event record with a description, creator, time, and room
+    """
+    models.Event.objects.create(**kwargs)

--- a/models.py
+++ b/models.py
@@ -183,6 +183,18 @@ class OutgoingConfig(models.Model):
         db_table = 'twote_outgoingconfig'
 
 
+class RetweetEvent(models.Model):
+    description = models.TextField()
+    start = models.DateTimeField()
+    location = models.CharField(max_length=100)
+    creator = models.CharField(max_length=100, blank=True, null=True)
+    created = models.DateTimeField(auto_now_add=True)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'twote_retweetevent'
+
+
 class Serializer(object):
     """Callable serializer. An instance of this class can be passed to the `default` arg in json.dump
 

--- a/streambot.py
+++ b/streambot.py
@@ -149,6 +149,10 @@ class Streambot:
                 message = message.format(screen_name, room, converted_time, tweet)
                 loggly.info(message)
 
+        else:
+            # tweet found but without valid time or room extracted, ignore
+            pass
+
 
 if __name__ == '__main__':
     bot = Streambot()

--- a/streambot.py
+++ b/streambot.py
@@ -120,15 +120,34 @@ class Streambot:
         val_check = [val for val in time_room.values() if len(val) == 1]
 
         if len(val_check) == 2:
-            self.send_mention_tweet(screen_name, 
-                                    time_room["room"][0],
-                                    time_room["date"][0])
+            room = time_room["room"][0]
+            converted_time = time_utils.convert_to_utc(time_room["date"][0])
 
-            parsed_date = time_room["date"][0]
-            talk_time = time_utils.convert_to_utc(parsed_date)
+            # check for a time and room conflict, only 1 set of retweets per event
+            conflict = db_utils.check_time_room_conflict(converted_time, room)
 
-            tweet_utils.schedule_tweets(screen_name, tweet, tweet_id, talk_time)
-            loggly.info("scheduled this tweet for retweet: {}".format(tweet))
+            if not conflict:
+                self.send_mention_tweet(screen_name, room, converted_time)
+
+                # This record lets us check that retweets not for same event
+                db_utils.create_event(
+                                      description=tweet,
+                                      start=converted_time, 
+                                      location=room,
+                                      creator=screen_name
+                                     )
+
+                tweet_utils.schedule_tweets(screen_name, tweet, tweet_id, converted_time)
+                loggly.info("scheduled this tweet for retweet: {}".format(tweet))
+
+            else:
+                message = """
+                            Tweet recived for an event bot is already scheduled
+                            to retweet about. Sender: {}, room: {}, time: {}, 
+                            tweet: {} 
+                          """
+                message = message.format(screen_name, room, converted_time, tweet)
+                loggly.info(message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bot checks to see if a tweet is for the exact time and room it has already scheduled a retweet for, if so it ignores the tweet and doesn't setup another retweet mention. This is done to limit the amount of times a bot can respond to a tweet about an event in case there are multiple people retweeting about a the same event. 